### PR TITLE
chore: use python in path instead of an absolute path to python

### DIFF
--- a/start_backend.bat
+++ b/start_backend.bat
@@ -7,5 +7,5 @@ echo Starting FastAPI backend on port 8000...
 echo API docs will be available at: http://localhost:8000/docs
 echo.
 cd backend
-C:\Users\satna\AppData\Local\Programs\Python\Python313\python.exe -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 pause


### PR DESCRIPTION
Currently the start_backend.bat file uses an absolute path to run the python executable, This pr aims to use the python which is probably in the path.